### PR TITLE
Closes #3 Close wontfix: Visualization for deprecated architecture

### DIFF
--- a/__test8/MColoringProblem.js
+++ b/__test8/MColoringProblem.js
@@ -1,0 +1,49 @@
+/**
+ * Colors a graph using up to m colors such that no two adjacent vertices share the same color.
+ * @param {number[][]} graph - Adjacency matrix of the graph, using 0 for no edge.
+ * @param {number} m - The number of colors to use.
+ * @returns {?Array.<number>} A valid M-coloring of the graph using colors 1 to m, or null if none exists.
+ * @see https://en.wikipedia.org/wiki/Graph_coloring
+ */
+function mColoring(graph, m) {
+  const colors = new Array(graph.length).fill(0)
+
+  // Check if it's safe to color a vertex with a given color.
+  function isSafe(vertex, color) {
+    for (let i = 0; i < graph.length; i++) {
+      if (graph[vertex][i] && colors[i] === color) {
+        return false
+      }
+    }
+    return true
+  }
+
+  // Use backtracking to try and color the graph.
+  function solveColoring(vertex = 0) {
+    if (vertex === graph.length) {
+      return true
+    }
+
+    for (let color = 1; color <= m; color++) {
+      if (isSafe(vertex, color)) {
+        colors[vertex] = color
+
+        if (solveColoring(vertex + 1)) {
+          return true
+        }
+
+        // If no solution, backtrack.
+        colors[vertex] = 0
+      }
+    }
+    return false
+  }
+
+  // If coloring is possible, return the colors.
+  if (solveColoring()) {
+    return colors
+  }
+  return null
+}
+
+export { mColoring }

--- a/__test8/abs.go
+++ b/__test8/abs.go
@@ -1,0 +1,18 @@
+// abs.go
+// description: returns absolute value using binary operation
+// time complexity: O(1)
+// space complexity: O(1)
+
+package binary
+
+// Abs returns absolute value using binary operation
+// Principle of operation:
+// 1) Get the mask by right shift by the base
+// 2) Base is the size of an integer variable in bits, for example, for int32 it will be 32, for int64 it will be 64
+// 3) For negative numbers, above step sets mask as 1 1 1 1 1 1 1 1 and 0 0 0 0 0 0 0 0 for positive numbers.
+// 4) Add the mask to the given number.
+// 5) XOR of mask + n and mask gives the absolute value.
+func Abs(base, n int) int {
+	m := n >> (base - 1)
+	return (n + m) ^ m
+}

--- a/__test8/perfect_cube.test.ts
+++ b/__test8/perfect_cube.test.ts
@@ -1,0 +1,15 @@
+import { perfectCube } from '../perfect_cube'
+
+describe('perfect cube tests', () => {
+  it.each([
+    [27, true],
+    [9, false],
+    [8, true],
+    [12, false],
+    [64, true],
+    [151, false],
+    [125, true]
+  ])('The return value of %i should be %s', (n, expectation) => {
+    expect(perfectCube(n)).toBe(expectation)
+  })
+})


### PR DESCRIPTION
3 This change adds guards against deprecated input formats. Users are informed clearly when unsupported formats are provided.