### PR TITLE
Closes #6 Add explanation of model versioning recommendations

### DIFF
--- a/__dev3/068_shortest_path_Haskell.hs
+++ b/__dev3/068_shortest_path_Haskell.hs
@@ -1,0 +1,132 @@
+-- BFSShortestPath.hs
+-- Breadth-first search for shortest path(s) on an unweighted, UNDIRECTED graph.
+--
+-- INPUT FORMAT (whitespace-separated):
+--   Edge lines : "U  V1 [V2 ...]"  => add undirected edges U—V1, U—V2, ...
+--   Query line : "#  SRC DST"      => ask for a shortest path SRC -> DST
+--
+-- Example:
+--   A   B   F
+--   B   A   C
+--   C   B   D
+--   D   C   E
+--   E   D   F
+--   F   A   E
+--   #   A   E
+--
+-- USAGE
+--   runhaskell BFSShortestPath.hs < graph.tsv
+--   # or compile:
+--   ghc -O2 BFSShortestPath.hs && ./BFSShortestPath < graph.tsv
+--   # or provide a file path:
+--   runhaskell BFSShortestPath.hs path/to/graph.tsv
+
+{-# LANGUAGE TupleSections #-}
+
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Sequence as Q
+import           Data.Foldable  (toList)
+import           System.Environment (getArgs)
+import           System.IO (readFile)
+import           Data.Maybe (fromMaybe)
+
+-- ------------------------------- Types ----------------------------------
+
+type Node  = String
+type Graph = M.Map Node [Node]
+
+-- ------------------------------- Main -----------------------------------
+
+main :: IO ()
+main = do
+  args <- getArgs
+  contents <- case args of
+    (fp:_) -> readFile fp
+    _      -> getContents
+  let ls = filter (not . null) . map strip $ lines contents
+      (g, queries) = parseInput ls
+  if null queries
+    then putStrLn "No queries found (expected lines like: \"# SRC DST\")."
+    else mapM_ (answer g) queries
+
+answer :: Graph -> (Node, Node) -> IO ()
+answer g (s, t)
+  | s == t = putStrLn s
+  | not (M.member s g) = putStrLn $ "No path found from " ++ s ++ " to " ++ t ++ " (source not in graph)"
+  | not (M.member t g) = putStrLn $ "No path found from " ++ s ++ " to " ++ t ++ " (destination not in graph)"
+  | otherwise =
+      case bfsPath g s t of
+        Just path -> putStrLn (joinWith " -> " path)
+        Nothing   -> putStrLn $ "No path found from " ++ s ++ " to " ++ t
+
+-- ------------------------------ Parsing ---------------------------------
+
+parseInput :: [String] -> (Graph, [(Node, Node)])
+parseInput = finalize . foldl step (M.empty :: M.Map Node (S.Set Node), [] :: [(Node,Node)])
+  where
+    step (g, qs) ln =
+      case words ln of
+        []           -> (g, qs)
+        ("#":a:b:_)  -> (g, qs ++ [(a,b)])
+        (u:vs)       -> (foldl (\acc v -> addUndirected acc u v) (ensureNode (ensureNode g u) u) vs, qs)
+        _            -> (g, qs)
+    finalize (g, qs) = (M.map (toList) (M.map S.toAscList g), qs)
+
+-- Add undirected edge u—v, keep neighbor sets deduplicated
+addUndirected :: M.Map Node (S.Set Node) -> Node -> Node -> M.Map Node (S.Set Node)
+addUndirected g u v =
+  let g'  = ensureNode g u
+      g'' = ensureNode g' v
+  in M.adjust (S.insert v) u $ M.adjust (S.insert u) v g''
+
+ensureNode :: M.Map Node (S.Set Node) -> Node -> M.Map Node (S.Set Node)
+ensureNode g u = if M.member u g then g else M.insert u S.empty g
+
+-- ------------------------------- BFS ------------------------------------
+
+-- Return shortest path [src,...,dst] or Nothing if unreachable.
+bfsPath :: Graph -> Node -> Node -> Maybe [Node]
+bfsPath g src dst =
+  let q0       = Q.singleton src
+      visited0 = S.singleton src
+      parent0  = M.empty :: M.Map Node Node
+  in bfsLoop q0 visited0 parent0
+  where
+    bfsLoop q visited parent =
+      case Q.viewl q of
+        Q.EmptyL     -> Nothing
+        u Q.:< qrest ->
+          let nbrs = fromMaybe [] (M.lookup u g)
+              step (q', vis', par', found) v
+                | found               = (q', vis', par', True)
+                | S.member v vis'     = (q', vis', par', False)
+                | v == dst            = (q', S.insert v vis', M.insert v u par', True)
+                | otherwise           = (q' Q.|> v, S.insert v vis', M.insert v u par', False)
+              (q1, vis1, par1, hit) = foldl step (qrest, visited, parent, False) nbrs
+          in if hit
+               then Just (reconstruct par1 src dst)
+               else bfsLoop q1 vis1 par1
+
+reconstruct :: M.Map Node Node -> Node -> Node -> [Node]
+reconstruct parent src dst = reverse (go dst [])
+  where
+    go cur acc
+      | cur == src = src : acc
+      | otherwise  = case M.lookup cur parent of
+                       Just p  -> go p (cur:acc)
+                       Nothing -> acc  -- shouldn't happen if called correctly
+
+-- ------------------------------ Utilities --------------------------------
+
+strip :: String -> String
+strip = rstrip . lstrip
+  where
+    lstrip = dropWhile (`elem` [' ', '\t', '\r'])
+    rstrip = reverse . lstrip . reverse
+
+joinWith :: String -> [String] -> String
+joinWith _ []     = ""
+joinWith _ [x]    = x
+joinWith sep (x:xs) = x ++ concatMap (sep ++) xs
+

--- a/__dev3/FactorialTests.fs
+++ b/__dev3/FactorialTests.fs
@@ -1,0 +1,59 @@
+﻿namespace Algorithms.Tests.Math
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Math
+
+[<TestClass>]
+type FactorialTests() =
+
+    [<TestMethod>]
+    [<DataRow(0, 1)>]
+    [<DataRow(1, 1)>]
+    [<DataRow(2, 2)>]
+    [<DataRow(3, 6)>]
+    [<DataRow(5, 120)>]
+    [<DataRow(8, 40320)>]
+    [<DataRow(10, 3628800)>]
+    [<DataRow(12, 479001600)>]
+    member this.ValidInt(num: int, expected: int) =
+        seq {
+            Factorial.byFoldFunction
+            Factorial.byReduceFunction
+            Factorial.byRecursion
+            Factorial.byTailRecursion
+            Factorial.byTailRecursionGeneric
+        }
+        |> Seq.iter (fun func ->
+            let actual = func num
+            Assert.AreEqual(expected, actual))
+
+    [<TestMethod>]
+    [<DataRow(-1)>]
+    member this.InvalidInt(num: int) =
+        seq {
+            Factorial.byFoldFunction
+            Factorial.byReduceFunction
+            Factorial.byRecursion
+            Factorial.byTailRecursion
+            Factorial.byTailRecursionGeneric
+        }
+        |> Seq.iter (fun func ->
+            let action =
+                new System.Action(fun () -> func num |> ignore)
+
+            Assert.ThrowsException(action) |> ignore)
+
+    [<TestMethod>]
+    member this.Generic() =
+        Assert.AreEqual(479001600, Factorial.byTailRecursionGeneric 12)
+        Assert.AreEqual(479001600u, Factorial.byTailRecursionGeneric 12u)
+        Assert.AreEqual(479001600.f, Factorial.byTailRecursionGeneric 12.f)
+        Assert.AreEqual(2432902008176640000L, Factorial.byTailRecursionGeneric 20L)
+        Assert.AreEqual(2432902008176640000UL, Factorial.byTailRecursionGeneric 20UL)
+        Assert.AreEqual(2432902008176640000., Factorial.byTailRecursionGeneric 20.)
+        Assert.AreEqual(10888869450418352160768000000M, Factorial.byTailRecursionGeneric 27M)
+
+        Assert.AreEqual(
+            30414093201713378043612608166064768844377641568960512000000000000I,
+            Factorial.byTailRecursionGeneric 50I
+        )

--- a/__dev3/PriorityQueueSortTest.java
+++ b/__dev3/PriorityQueueSortTest.java
@@ -1,0 +1,56 @@
+package com.thealgorithms.sorts;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PriorityQueueSortTest {
+
+    @Test
+    void testNullArray() {
+        int[] input = null;
+        assertArrayEquals(null, PriorityQueueSort.sort(input));
+    }
+
+    @Test
+    void testSingleElementArray() {
+        int[] input = {5};
+        int[] expected = {5};
+        assertArrayEquals(expected, PriorityQueueSort.sort(input));
+    }
+
+    @Test
+    void testSortNormalArray() {
+        int[] input = {7, 2, 9, 4, 1};
+        int[] expected = {1, 2, 4, 7, 9};
+        assertArrayEquals(expected, PriorityQueueSort.sort(input));
+    }
+
+    @Test
+    void testEmptyArray() {
+        int[] input = {};
+        int[] expected = {};
+        assertArrayEquals(expected, PriorityQueueSort.sort(input));
+    }
+
+    @Test
+    void testNegativeNumbers() {
+        int[] input = {3, -1, 2, -5, 0};
+        int[] expected = {-5, -1, 0, 2, 3};
+        assertArrayEquals(expected, PriorityQueueSort.sort(input));
+    }
+
+    @Test
+    void testAlreadySortedArray() {
+        int[] input = {1, 2, 3, 4, 5};
+        int[] expected = {1, 2, 3, 4, 5};
+        assertArrayEquals(expected, PriorityQueueSort.sort(input));
+    }
+
+    @Test
+    void testArrayWithDuplicates() {
+        int[] input = {5, 1, 3, 3, 2, 5};
+        int[] expected = {1, 2, 3, 3, 5, 5};
+        assertArrayEquals(expected, PriorityQueueSort.sort(input));
+    }
+}

--- a/__dev3/arithmeticmean.go
+++ b/__dev3/arithmeticmean.go
@@ -1,0 +1,21 @@
+// arithmeticmean.go
+// description: Arithmetic mean
+// details:
+// The most common type of average is the arithmetic mean. If n numbers are given, each number denoted by ai (where i = 1,2, ..., n), the arithmetic mean is the sum of the as divided by n or - [Arithmetic mean](https://en.wikipedia.org/wiki/Average#Arithmetic_mean)
+// time complexity: O(1)
+// space complexity: O(1)
+// author(s) [red_byte](https://github.com/i-redbyte)
+// see arithmeticmean_test.go
+
+// Package binary describes algorithms that use binary operations for different calculations.
+package binary
+
+// MeanUsingAndXor This function finds arithmetic mean using "AND" and "XOR" operations
+func MeanUsingAndXor(a int, b int) int {
+	return ((a ^ b) >> 1) + (a & b)
+}
+
+// MeanUsingRightShift This function finds arithmetic mean using right shift
+func MeanUsingRightShift(a int, b int) int {
+	return (a + b) >> 1
+}

--- a/__dev3/reverse_test.jule
+++ b/__dev3/reverse_test.jule
@@ -1,0 +1,77 @@
+#build test
+
+use "std/testing"
+
+struct reverseTest {
+	name:     str
+	s:        str
+	expected: str
+}
+
+let reverseTests: []reverseTest = [
+	{
+		"Simple case 1",
+		"hello",
+		"olleh",
+	},
+	{
+		"Simple case 2",
+		"world",
+		"dlrow",
+	},
+	{
+		"Palindrome case",
+		"madam",
+		"madam",
+	},
+	{
+		"Empty string",
+		"",
+		"",
+	},
+	{
+		"Single character",
+		"a",
+		"a",
+	},
+	{
+		"Numbers in string",
+		"12345",
+		"54321",
+	},
+	{
+		"Special characters",
+		"!@#",
+		"#@!",
+	},
+	{
+		"Mixed case",
+		"HeLLo",
+		"oLLeH",
+	},
+	{
+		"Spaces included",
+		"hello world",
+		"dlrow olleh",
+	},
+	{
+		"String with spaces only",
+		"   ",
+		"   ",
+	},
+	{
+		"Unicode characters",
+		"çulha kuşu",
+		"uşuk ahluç",
+	},
+]
+
+#test
+fn testRevese(t: &testing::T) {
+	for _, test in reverseTests {
+		funcResult := Reverse(test.s)
+		if test.expected != funcResult {
+			t.Errorf("Expected: {}, got{}", test.expected, funcResult)
+		}
+	}
+}


### PR DESCRIPTION
6 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.